### PR TITLE
Update pip dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,9 @@
 tensorflow-gpu>=1.5
 progressbar2>=3.0
 numpy>=1.13
-opencv-python>=3.2
+opencv-python>=3.2,<=4.2.0.32
 scikit-learn>=0.18
 scipy>=0.18
 matplotlib>=1.5
 Pillow>=3.1.2
-nvidia-ml-py>=375.53.1
+nvidia-ml-py>=375.53


### PR DESCRIPTION
Installing from the requirements.txt currently errors out. This PR fixes two issues:
- opencv dropped python2 support, so use the [latest](https://stackoverflow.com/a/63355706/1337136) with support
- the 375.53.1 tag of nvidia-ml-py no longer exists, so use the closest version